### PR TITLE
configure what files to exclude in code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "devDependencies": {
     "@vitest/coverage-v8": "^1.3.1",
     "rimraf": "^5.0.5",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+    test: {
+        coverage: {
+            provider: 'v8',
+            exclude: ['built']
+        }
+    }
+})


### PR DESCRIPTION
only include ts files in the coverage report.

![image](https://github.com/96jonesa/BaSim/assets/69741747/0f34b01f-78b3-4b06-958e-2db2b2d4e6c6)
